### PR TITLE
Fix clipboard and its integration with shell

### DIFF
--- a/AbacusActivity.py
+++ b/AbacusActivity.py
@@ -342,16 +342,16 @@ class AbacusActivity(activity.Activity):
 
     def _copy_cb(self, arg=None):
         ''' Copy a number to the clipboard from the active abacus. '''
-        clipBoard = Gtk.Clipboard()
+        clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
         text = self.abacus.generate_label(sum_only=True)
         if text is not None:
-            clipBoard.set_text(text)
+            clipboard.set_text(text, -1)
         return
 
     def _paste_cb(self, arg=None):
         ''' Paste a number from the clipboard to the active abacus. '''
-        clipBoard = Gtk.Clipboard()
-        text = clipBoard.wait_for_text()
+        clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
+        text = clipboard.wait_for_text()
         if text is not None:
             try:
                 self.abacus.mode.set_value_from_number(float(text))


### PR DESCRIPTION
The cliboard was broken, could not copy nor paste. The problem
was that we were not using any particular clipboard and we were
not providing all the arguments necessary to set_text.

Therefore, use Gdk.SELECTION_CLIPBOARD, which is the proper one to
use in this case and pass -1 second argument to set_text [1]. This
also fixes the integration with the sugar shell clipboard.

Tested on Fedora 21 and Ubuntu 14.04.

[1] https://developer.gnome.org/gtk3/3.8/gtk3-Clipboards.html

Signed-off-by: Martin Abente Lahaye tch@sugarlabs.org
