### PR TITLE
Fix abacus beads label to show string instead of bytes

### DIFF
--- a/abacus_window.py
+++ b/abacus_window.py
@@ -727,7 +727,7 @@ class Rod():
         # Use hex notation on hex abacus
         if self.top_beads == 1 and self.bot_beads == 7 and \
                 self.top_factor == 8:
-            self.label.set_label('%x' % n)
+            self.label.set_label('%x' % int(n))
         # Only show 0 on binary abacus
         elif n == 0 and not (self.top_beads == 0 and self.bot_beads == 1):
             self.label.set_label('')
@@ -1305,6 +1305,8 @@ class AbacusGeneric():
 
     def label(self, string):
         ''' Label with the string. (Used with self.value) '''
+        if type(string) is not str:
+            string = str(string)
         self.label_bar.set_label(string)
 
     def move_mark(self, dx):

--- a/sprites.py
+++ b/sprites.py
@@ -276,7 +276,7 @@ class Sprite:
             # pango doesn't like nulls
             self.labels[i] = new_label.replace("\0", " ")
         else:
-            self.labels[i] = str(new_label).encode()
+            self.labels[i] = str(new_label)
         self.inval()
 
     def set_margins(self, left=0, top=0, right=0, bottom=0):


### PR DESCRIPTION
Fixes #19
Abacus beads and the labels under them showed bytes instead of strings. This was
caused due to a regression in the Python3 port. All integers were forced
to be converted to strings before redraw.
