### PR TITLE
Bug Fix: Top left Bead overflows on reset

### DIFF
--- a/abacus_window.py
+++ b/abacus_window.py
@@ -622,7 +622,7 @@ class Rod():
         # Clear the top.
         for i in range(self.top_beads):
             if self.beads[i + self._bead_count].get_state() == 1:
-                self.beads[i].move_up()
+                self.beads[i + self._bead_count].move_up()
         # Clear the bottom.
         for i in range(self.bot_beads):
             if self.beads[self.top_beads + i + self._bead_count].get_state() \


### PR DESCRIPTION
## Reproduce the bug
1. Start the activity
2. Move one of the top beads down
3. Hit reset
4. Notice that the top beads bug out (either disappear or don't move back up to their initial position or sometimes move outside the abacus space)

![screentshot1](https://user-images.githubusercontent.com/96080203/219280824-2ca147d0-c5d8-476e-903f-cf7e56eff218.jpg)
> The screenshot shows the behavior before this change